### PR TITLE
Add heart rate gauge

### DIFF
--- a/HRV app/HeartRateGaugeView.swift
+++ b/HRV app/HeartRateGaugeView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct HeartRateGaugeView: View {
+    let heartRate: Double
+
+    var body: some View {
+        Gauge(value: heartRate, in: 40...120) {
+            Text("Resting HR")
+        } currentValueLabel: {
+            Text("\(Int(heartRate)) bpm")
+                .font(.headline)
+        }
+        .gaugeStyle(.accessoryCircular)
+        .tint(AngularGradient(
+            gradient: Gradient(colors: [.green, .yellow, .orange, .red]),
+            center: .center)
+        )
+        .frame(width: 150, height: 150)
+    }
+}
+
+#Preview {
+    HeartRateGaugeView(heartRate: 65)
+}

--- a/HRV app/SnapshotView.swift
+++ b/HRV app/SnapshotView.swift
@@ -3,19 +3,34 @@ import SwiftUI
 struct SnapshotView: View {
     @ObservedObject var dataManager: AppDataManager
 
+    private var restingHR: Double? {
+        if let point = dataManager.dataPoints.first(where: { $0.title == "Resting HR" }) {
+            let value = point.value.replacingOccurrences(of: " bpm", with: "")
+            return Double(value)
+        }
+        return nil
+    }
+
     var body: some View {
         NavigationStack {
-            List(dataManager.dataPoints) { point in
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(point.title)
-                        .font(.headline)
-                    Text(point.value)
-                        .font(.subheadline)
-                    Text(point.timestamp, style: .time)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+            List {
+                if let hr = restingHR {
+                    Section {
+                        HStack { Spacer(); HeartRateGaugeView(heartRate: hr); Spacer() }
+                    }
                 }
-                .padding(4)
+                ForEach(dataManager.dataPoints) { point in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(point.title)
+                            .font(.headline)
+                        Text(point.value)
+                            .font(.subheadline)
+                        Text(point.timestamp, style: .time)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(4)
+                }
             }
             .navigationTitle("Health Snapshot")
             .onAppear {


### PR DESCRIPTION
## Summary
- create `HeartRateGaugeView` gauge to visualize resting heart rate
- show new gauge at the top of `SnapshotView`

## Testing
- `swift --version`
- `for f in 'HRV app'/*.swift; do swiftc -emit-sil "$f"; done` *(fails: no such module `SwiftUI`)*

------
https://chatgpt.com/codex/tasks/task_e_684b93edd47883248147cebf637737a3