### PR TITLE
Fix gauge row spacing

### DIFF
--- a/HRV app/SnapshotView.swift
+++ b/HRV app/SnapshotView.swift
@@ -15,10 +15,9 @@ struct SnapshotView: View {
         NavigationStack {
             List {
                 if let value = hrvValue {
-                    Section {
-                        HRVGaugeView(hrv: value)
-                            .frame(maxWidth: .infinity)
-                    }
+                    HRVGaugeView(hrv: value)
+                        .frame(maxWidth: .infinity)
+                        .listRowInsets(EdgeInsets())
                 }
                 ForEach(dataManager.dataPoints) { point in
                     VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
## Summary
- reduce vertical padding around the HRV gauge by removing the extra section wrapper

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684b972eaf808324924638082f846564