### PR TITLE
Add resting heart rate gauge

### DIFF
--- a/HRV app/HeartRateGaugeView.swift
+++ b/HRV app/HeartRateGaugeView.swift
@@ -17,11 +17,34 @@ struct HRVGaugeView: View {
             gradient: Gradient(colors: [.green, .yellow, .orange, .red]),
             center: .center)
         )
-        // Slightly larger to better fill the list card
-        .frame(width: 200, height: 200)
+        .frame(width: 150, height: 150)
+    }
+}
+
+/// Circular gauge to visualize Resting Heart Rate.
+struct HeartRateGaugeView: View {
+    /// Resting heart rate in beats per minute
+    let heartRate: Double
+
+    var body: some View {
+        Gauge(value: heartRate, in: 40...120) {
+            Text("Resting HR")
+        } currentValueLabel: {
+            Text("\(Int(heartRate)) bpm")
+                .font(.headline)
+        }
+        .gaugeStyle(.accessoryCircular)
+        .tint(AngularGradient(
+            gradient: Gradient(colors: [.green, .yellow, .orange, .red]),
+            center: .center)
+        )
+        .frame(width: 150, height: 150)
     }
 }
 
 #Preview {
-    HRVGaugeView(hrv: 65)
+    VStack {
+        HRVGaugeView(hrv: 65)
+        HeartRateGaugeView(heartRate: 60)
+    }
 }

--- a/HRV app/SnapshotView.swift
+++ b/HRV app/SnapshotView.swift
@@ -11,13 +11,27 @@ struct SnapshotView: View {
         return nil
     }
 
+    private var restingHR: Double? {
+        if let point = dataManager.dataPoints.first(where: { $0.title == "Resting HR" }) {
+            let value = point.value.replacingOccurrences(of: " bpm", with: "")
+            return Double(value)
+        }
+        return nil
+    }
+
     var body: some View {
         NavigationStack {
             List {
-                if let value = hrvValue {
-                    HRVGaugeView(hrv: value)
-                        .frame(maxWidth: .infinity)
-                        .listRowInsets(EdgeInsets())
+                if let hrv = hrvValue {
+                    HStack {
+                        HRVGaugeView(hrv: hrv)
+                        if let hr = restingHR {
+                            Spacer()
+                            HeartRateGaugeView(heartRate: hr)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .listRowInsets(EdgeInsets())
                 }
                 ForEach(dataManager.dataPoints) { point in
                     VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
## Summary
- add an HR gauge next to the existing HRV gauge
- display the gauges side by side in the snapshot

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684c33e0eaa083249616f48d46b2c574