### PR TITLE
Add charts, settings, widget

### DIFF
--- a/HRV app/ContentView.swift
+++ b/HRV app/ContentView.swift
@@ -3,17 +3,28 @@ import SwiftData
 
 struct ContentView: View {
     @StateObject private var dataManager = AppDataManager()
+    @StateObject private var settings = UserSettings()
 
     var body: some View {
         TabView {
-            SnapshotView(dataManager: dataManager)
+            SnapshotView(dataManager: dataManager, settings: settings)
                 .tabItem {
                     Label("Snapshot", systemImage: "waveform.path.ecg")
+                }
+
+            TrendsView(dataManager: dataManager)
+                .tabItem {
+                    Label("Trends", systemImage: "chart.line.uptrend.xyaxis")
                 }
 
             ChatView(dataManager: dataManager)
                 .tabItem {
                     Label("Chat", systemImage: "bubble.left.and.bubble.right")
+                }
+
+            SettingsView(settings: settings)
+                .tabItem {
+                    Label("Settings", systemImage: "gear")
                 }
         }
     }

--- a/HRV app/HRVRecord.swift
+++ b/HRV app/HRVRecord.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct HRVRecord: Identifiable, Codable {
+    let id = UUID()
+    let date: Date
+    let value: Int
+}

--- a/HRV app/SettingsView.swift
+++ b/HRV app/SettingsView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var settings: UserSettings
+
+    var body: some View {
+        Form {
+            Toggle("Show HRV", isOn: $settings.showHRV)
+            Toggle("Show Resting HR", isOn: $settings.showRestingHR)
+            Toggle("Show Sleep", isOn: $settings.showSleep)
+            Toggle("Show Mindful Minutes", isOn: $settings.showMindful)
+            Toggle("Show Steps", isOn: $settings.showSteps)
+            Toggle("Show Active Energy", isOn: $settings.showEnergy)
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+#Preview {
+    SettingsView(settings: UserSettings())
+}

--- a/HRV app/SnapshotView.swift
+++ b/HRV app/SnapshotView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SnapshotView: View {
     @ObservedObject var dataManager: AppDataManager
+    @ObservedObject var settings: UserSettings
 
     private var hrvValue: Double? {
         if let point = dataManager.dataPoints.first(where: { $0.title == "HRV" }) {
@@ -11,15 +12,27 @@ struct SnapshotView: View {
         return nil
     }
 
+    private func shouldShow(_ title: String) -> Bool {
+        switch title {
+        case "HRV": return settings.showHRV
+        case "Resting HR": return settings.showRestingHR
+        case "Sleep": return settings.showSleep
+        case "Mindful Minutes": return settings.showMindful
+        case "Steps": return settings.showSteps
+        case "Active Energy": return settings.showEnergy
+        default: return true
+        }
+    }
+
     var body: some View {
         NavigationStack {
             List {
-                if let value = hrvValue {
+                if let value = hrvValue, settings.showHRV {
                     HRVGaugeView(hrv: value)
                         .frame(maxWidth: .infinity)
                         .listRowInsets(EdgeInsets())
                 }
-                ForEach(dataManager.dataPoints) { point in
+                ForEach(dataManager.dataPoints.filter { shouldShow($0.title) }) { point in
                     VStack(alignment: .leading, spacing: 4) {
                         Text(point.title)
                             .font(.headline)
@@ -44,5 +57,5 @@ struct SnapshotView: View {
 }
 
 #Preview {
-    SnapshotView(dataManager: AppDataManager())
+    SnapshotView(dataManager: AppDataManager(), settings: UserSettings())
 }

--- a/HRV app/TrendsView.swift
+++ b/HRV app/TrendsView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import Charts
+
+struct TrendsView: View {
+    @ObservedObject var dataManager: AppDataManager
+
+    var body: some View {
+        NavigationStack {
+            Chart(dataManager.hrvHistory) { record in
+                LineMark(
+                    x: .value("Date", record.date),
+                    y: .value("HRV", record.value)
+                )
+            }
+            .chartYScale(domain: 0...200)
+            .padding()
+            .navigationTitle("HRV Trends")
+        }
+    }
+}
+
+#Preview {
+    let dm = AppDataManager()
+    dm.hrvHistory = [
+        HRVRecord(date: .now.addingTimeInterval(-3600*24*4), value: 60),
+        HRVRecord(date: .now.addingTimeInterval(-3600*24*3), value: 55),
+        HRVRecord(date: .now.addingTimeInterval(-3600*24*2), value: 70),
+        HRVRecord(date: .now.addingTimeInterval(-3600*24), value: 65)
+    ]
+    return TrendsView(dataManager: dm)
+}

--- a/HRV app/UserSettings.swift
+++ b/HRV app/UserSettings.swift
@@ -1,0 +1,12 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class UserSettings: ObservableObject {
+    @AppStorage("showHRV") var showHRV: Bool = true
+    @AppStorage("showRestingHR") var showRestingHR: Bool = true
+    @AppStorage("showSleep") var showSleep: Bool = true
+    @AppStorage("showMindful") var showMindful: Bool = true
+    @AppStorage("showSteps") var showSteps: Bool = true
+    @AppStorage("showEnergy") var showEnergy: Bool = true
+}

--- a/HRVWidgetExtension/HRVWidget.swift
+++ b/HRVWidgetExtension/HRVWidget.swift
@@ -1,0 +1,55 @@
+import WidgetKit
+import SwiftUI
+
+struct HRVEntry: TimelineEntry {
+    let date: Date
+    let hrv: Int
+}
+
+struct HRVProvider: TimelineProvider {
+    func placeholder(in context: Context) -> HRVEntry {
+        HRVEntry(date: .now, hrv: 65)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (HRVEntry) -> Void) {
+        completion(placeholder(in: context))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<HRVEntry>) -> Void) {
+        let entry = HRVEntry(date: .now, hrv: loadHRV())
+        let next = Calendar.current.date(byAdding: .hour, value: 1, to: .now) ?? .now
+        completion(Timeline(entries: [entry], policy: .after(next)))
+    }
+
+    private func loadHRV() -> Int {
+        if let data = UserDefaults.standard.data(forKey: "hrvHistory"),
+           let records = try? JSONDecoder().decode([HRVRecord].self, from: data),
+           let last = records.last {
+            return last.value
+        }
+        return 0
+    }
+}
+
+struct HRVWidgetEntryView : View {
+    var entry: HRVProvider.Entry
+
+    var body: some View {
+        VStack {
+            Text("HRV")
+            Text("\(entry.hrv) ms")
+        }
+    }
+}
+
+@main
+struct HRVWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "HRVWidget", provider: HRVProvider()) { entry in
+            HRVWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Current HRV")
+        .description("Shows your most recent HRV value")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}


### PR DESCRIPTION
## Summary
- store HRV history and persist to UserDefaults
- add Trends view with Swift Charts
- allow customizing metric visibility in new Settings view
- show/hide metrics in Snapshot view based on settings
- include a WidgetKit extension to display latest HRV value
- add tabs for Trends and Settings

## Testing
- `swiftc --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684cd3627bdc83248c335e2716ca365b