### PR TITLE
Fix preview builder

### DIFF
--- a/HRV app/TrendsView.swift
+++ b/HRV app/TrendsView.swift
@@ -27,5 +27,5 @@ struct TrendsView: View {
         HRVRecord(date: .now.addingTimeInterval(-3600*24*2), value: 70),
         HRVRecord(date: .now.addingTimeInterval(-3600*24), value: 65)
     ]
-    return TrendsView(dataManager: dm)
+    TrendsView(dataManager: dm)
 }


### PR DESCRIPTION
## Summary
- remove explicit `return` from `TrendsView` preview

## Testing
- `swiftc 'HRV app/TrendsView.swift' -o /tmp/TrendsView` *(fails: no such module 'SwiftUI')*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684cd8d316248324b7163e7c1b1b358a