### PR TITLE
Fix preview HRV history assignment

### DIFF
--- a/HRV app/AppDataManager.swift
+++ b/HRV app/AppDataManager.swift
@@ -35,6 +35,13 @@ class AppDataManager: NSObject, ObservableObject {
         }
     }
 
+#if DEBUG
+    /// Allows previews and tests to provide sample HRV history data.
+    func setHRVHistory(_ records: [HRVRecord]) {
+        self.hrvHistory = records
+    }
+#endif
+
     func requestAuthorization() {
         // HealthKit types
         let healthTypes: Set = [

--- a/HRV app/TrendsView.swift
+++ b/HRV app/TrendsView.swift
@@ -21,11 +21,11 @@ struct TrendsView: View {
 
 #Preview {
     let dm = AppDataManager()
-    dm.hrvHistory = [
+    dm.setHRVHistory([
         HRVRecord(date: .now.addingTimeInterval(-3600*24*4), value: 60),
         HRVRecord(date: .now.addingTimeInterval(-3600*24*3), value: 55),
         HRVRecord(date: .now.addingTimeInterval(-3600*24*2), value: 70),
         HRVRecord(date: .now.addingTimeInterval(-3600*24), value: 65)
-    ]
+    ])
     TrendsView(dataManager: dm)
 }


### PR DESCRIPTION
## Summary
- add a debug-only helper on `AppDataManager` to set HRV history
- use the helper in `TrendsView` preview to avoid a private setter error

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684cda1a81d08324b54355b88a0d6dc2