### PR TITLE
Fix ForEach id typo

### DIFF
--- a/HRV app/TrendsView.swift
+++ b/HRV app/TrendsView.swift
@@ -8,7 +8,7 @@ struct TrendsView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 16) {
-                    ForEach(dataManager.metricHistories.keys.sorted(), id: \.elf) { key in
+                    ForEach(dataManager.metricHistories.keys.sorted(), id: \.self) { key in
                         if let records = dataManager.metricHistories[key] {
                             MetricChartCard(title: key, records: records)
                         }


### PR DESCRIPTION
## Summary
- fix the `ForEach` identifier to use `.self` so dictionary keys render correctly

## Testing
- `swiftc 'HRV app/TrendsView.swift' -o /tmp/a.out` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684e591fc8bc8324a91895e64441c1c6