### PR TITLE
Add foundation-powered insight card

### DIFF
--- a/HRV app/InsightCardView.swift
+++ b/HRV app/InsightCardView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import FoundationModels
+
+@MainActor
+class InsightViewModel: ObservableObject {
+    @Published var insight: String = ""
+    private let model = SystemLanguageModel.default
+    private let dataProvider: () -> [DataPoint]
+    private var timer: Timer?
+
+    init(dataProvider: @escaping () -> [DataPoint]) {
+        self.dataProvider = dataProvider
+        scheduleTimer()
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    private func scheduleTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { [weak self] _ in
+            Task { await self?.generateInsight() }
+        }
+    }
+
+    func generateInsight() async {
+        guard model.availability == .available else { return }
+        let context = dataProvider()
+            .map { "\($0.title): \($0.value)" }
+            .joined(separator: ", ")
+        let session = LanguageModelSession(
+            model: model,
+            instructions: "Provide a brief health insight using two sentences or less based on: \(context)"
+        )
+        do {
+            let result = try await session.respond(to: Prompt("Insight"))
+            insight = result.content
+        } catch {
+            // Ignore failures
+        }
+    }
+}
+
+struct InsightCardView: View {
+    @StateObject var viewModel: InsightViewModel
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            if viewModel.insight.isEmpty {
+                ProgressView()
+            } else {
+                Text(viewModel.insight)
+                    .font(.body)
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
+        .task { await viewModel.generateInsight() }
+    }
+}
+
+#Preview {
+    InsightCardView(viewModel: InsightViewModel(dataProvider: { [] }))
+}

--- a/HRV app/SnapshotView.swift
+++ b/HRV app/SnapshotView.swift
@@ -3,6 +3,13 @@ import SwiftUI
 struct SnapshotView: View {
     @ObservedObject var dataManager: AppDataManager
     @ObservedObject var settings: UserSettings
+    @StateObject private var insightVM: InsightViewModel
+
+    init(dataManager: AppDataManager, settings: UserSettings) {
+        self.dataManager = dataManager
+        self.settings = settings
+        _insightVM = StateObject(wrappedValue: InsightViewModel(dataProvider: { dataManager.dataPoints }))
+    }
 
     private var hrvValue: Double? {
         if let point = dataManager.dataPoints.first(where: { $0.title == "HRV" }) {
@@ -27,6 +34,8 @@ struct SnapshotView: View {
     var body: some View {
         NavigationStack {
             List {
+                InsightCardView(viewModel: insightVM)
+                    .listRowInsets(EdgeInsets())
                 if let value = hrvValue, settings.showHRV {
                     HRVGaugeView(hrv: value)
                         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- generate a short insight from recent metrics via Foundation model
- show the insight card at the top of the Snapshot tab

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684ebc37608c83249399cb88f9c69d54